### PR TITLE
Bin packing problem with items arrving in a known order (so that it can be sorted) using First Fit Decreasing algorithm

### DIFF
--- a/src/greedyalgorithms/BinPackingFirstFitDecreasing.java
+++ b/src/greedyalgorithms/BinPackingFirstFitDecreasing.java
@@ -1,0 +1,46 @@
+package greedyalgorithms;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class BinPackingFirstFitDecreasing {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		  Integer weight[] = { 2, 5, 4, 7, 1, 3, 8 }; 
+		  int c = 10; 
+		  int n = weight.length; 
+		  
+		  Arrays.sort(weight, Collections.reverseOrder());
+		  for(int i=0; i<n; i++) 
+		  {
+			  System.out.println(weight[i]);
+		  }
+		  System.out.println("Number of bins required in Next Fit : " + firstFit(weight, n, c)); 
+	}
+	
+	public static int firstFit(Integer[] w, int n, int c)
+	{
+		int res = 0; 
+		int[] bins = new int[n];
+		
+		for(int i=0; i<n; i++)
+		{
+			int j;
+			for(j=0; j<res; j++)
+			{
+				if(bins[j] >= w[i])
+				{
+					bins[j] -= w[i];
+					break;
+				}
+			}
+			if(j == res)
+			{
+				bins[j] = c - w[i];
+				res++;
+			}
+		}
+		return res;
+	}
+}


### PR DESCRIPTION
Bin packing problem with items arrving in a known order (so that it can be sorted) using First Fit Decreasing algorithm

Given a universe U of n elements, a collection of subsets of U say S = {S1, S2…,Sm} where every subset Si has an associated cost. Find a minimum cost subcollection of S that covers all elements of U.

**Offline Algorithms**

In the offline version, we have all items upfront. Unfortunately offline version is also NP Complete, but we have a better approximate algorithm for it. First Fit Decreasing uses at most (4M + 1)/3 bins if the optimal is M.

**4. First Fit Decreasing:**
A trouble with online algorithms is that packing large items is difficult, especially if they occur late in the sequence. We can circumvent this by *sorting* the input sequence, and placing the large items first. With sorting, we get First Fit Decreasing and Best Fit Decreasing, as offline analogs of online First Fit and Best Fit.
